### PR TITLE
Refactor: separate data and builder in mapping layer

### DIFF
--- a/mapping/build.go
+++ b/mapping/build.go
@@ -1,0 +1,184 @@
+package mapping
+
+import "reflect"
+
+// EntityMetadata contains all configuration needed to build an EntityMapping.
+// This is a pure data structure with no dependencies on the orm1 package.
+type EntityMetadata struct {
+	Schema string
+	Table  string
+	Fields []FieldMetadata // All fields analyzed from the struct
+}
+
+// BuildEntityMappings constructs EntityMapping instances from metadata.
+// This function is the core builder that transforms metadata into entity mappings.
+//
+// The build process:
+//  1. Analyze each entity's struct fields using AnalyzeStruct
+//  2. Detect child relationships based on registered types
+//  3. Construct field maps, child maps, and key configurations
+//  4. Create EntityMapping instances
+//
+// Parameters:
+//   - meta: Map of entity types to their metadata
+//   - registered: Set of all registered entity types (for child detection)
+//
+// Returns: Map of entity types to their complete EntityMapping instances
+func BuildEntityMappings(
+	meta map[reflect.Type]EntityMetadata,
+	registered map[reflect.Type]bool,
+) map[reflect.Type]*EntityMapping {
+	result := make(map[reflect.Type]*EntityMapping, len(meta))
+
+	for entityType, entityMeta := range meta {
+		mapping := buildSingleMapping(entityType, entityMeta, registered)
+		result[entityType] = mapping
+	}
+
+	return result
+}
+
+// buildSingleMapping constructs an EntityMapping for a single entity type.
+func buildSingleMapping(
+	entityType reflect.Type,
+	entityMeta EntityMetadata,
+	registered map[reflect.Type]bool,
+) *EntityMapping {
+	fieldMap := make(map[string]*Field)
+	childMap := make(map[string]*Child)
+	allFields := []string{}
+	primaryKey := []string{}
+	parentalKey := []string{}
+	insertable := []string{}
+	updatable := []string{}
+
+	for _, metadata := range entityMeta.Fields {
+		fieldName := metadata.Name
+		fieldType := metadata.Typ
+
+		if metadata.IgnoreTag {
+			continue
+		}
+
+		isChild := metadata.ChildTag
+		var childTarget reflect.Type
+		var childSingular bool
+
+		if !isChild {
+			// Auto-detect child relationship if not explicitly tagged
+			// Check for slice of registered type: []*Post
+			if fieldType.Kind() == reflect.Slice {
+				elemType := fieldType.Elem()
+				if elemType.Kind() == reflect.Ptr {
+					targetType := elemType.Elem()
+					if registered[targetType] {
+						isChild = true
+						childTarget = targetType
+						childSingular = false
+					}
+				}
+			}
+
+			if !isChild && fieldType.Kind() == reflect.Ptr {
+				targetType := fieldType.Elem()
+				if registered[targetType] {
+					isChild = true
+					childTarget = targetType
+					childSingular = true
+				}
+			}
+		} else {
+			if fieldType.Kind() == reflect.Slice {
+				elemType := fieldType.Elem()
+				if elemType.Kind() == reflect.Ptr {
+					childTarget = elemType.Elem()
+					childSingular = false
+				}
+			} else if fieldType.Kind() == reflect.Ptr {
+				childTarget = fieldType.Elem()
+				childSingular = true
+			}
+		}
+
+		if isChild {
+			child := Child{
+				Target:     childTarget,
+				Singular:   childSingular,
+				Type:       fieldType,
+				ByteOffset: metadata.ByteOffset,
+			}
+			childMap[fieldName] = &child
+			continue
+		}
+
+		if fieldType.Kind() == reflect.Slice {
+			continue
+		}
+
+		if fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct {
+			continue
+		}
+
+		columnName := metadata.ColumnTag
+		if columnName == "" {
+			columnName = metadata.DefaultColumn
+		}
+
+		field := Field{
+			Name:       metadata.Name,
+			Column:     columnName,
+			Type:       metadata.Typ,
+			ByteOffset: metadata.ByteOffset,
+		}
+
+		fieldMap[fieldName] = &field
+
+		isPrimaryKey := metadata.PrimaryTag
+		isParentalKey := metadata.ParentalTag
+
+		// Default: ID field is primary key if no explicit primary tag
+		if !isPrimaryKey && !isParentalKey && fieldName == "ID" {
+			isPrimaryKey = true
+		}
+
+		// Add to AllFields (all fields are included regardless of role)
+		allFields = append(allFields, fieldName)
+
+		// A field can be both primary and parental (e.g., 1:1 relationship where PK=FK)
+		if isPrimaryKey {
+			primaryKey = append(primaryKey, fieldName)
+		}
+		if isParentalKey {
+			parentalKey = append(parentalKey, fieldName)
+		}
+
+		if isPrimaryKey || isParentalKey {
+			// Primary/parental keys are insertable unless tagged skip_insert
+			if !metadata.SkipInsertTag {
+				insertable = append(insertable, fieldName)
+			}
+			// Primary/parental keys are not updatable (they define identity)
+		} else {
+			// Regular fields are insertable and updatable unless tagged otherwise
+			if !metadata.SkipInsertTag {
+				insertable = append(insertable, fieldName)
+			}
+			if !metadata.SkipUpdateTag {
+				updatable = append(updatable, fieldName)
+			}
+		}
+	}
+
+	return NewEntityMapping(
+		entityType,
+		entityMeta.Schema,
+		entityMeta.Table,
+		fieldMap,
+		childMap,
+		allFields,
+		primaryKey,
+		parentalKey,
+		insertable,
+		updatable,
+	)
+}

--- a/mapping/extract_test.go
+++ b/mapping/extract_test.go
@@ -295,28 +295,35 @@ func TestExtractKey_KeyEquality(t *testing.T) {
 
 // Helper function to create EntityMapping for test
 func createEntityMapping(fieldNames []string) *mapping.EntityMapping {
-	fieldMap := make(map[string]*mapping.Field)
-
 	entityType := reflect.TypeOf(Entity{})
+
+	// Analyze struct and mark specified fields as primary
+	fields := mapping.AnalyzeStruct(entityType)
+
+	// Override PrimaryTag for specified fields
+	isPrimaryField := make(map[string]bool)
 	for _, name := range fieldNames {
-		field, _ := entityType.FieldByName(name)
-		fieldMap[name] = &mapping.Field{
-			Name:       name,
-			Column:     name,
-			Type:       field.Type,
-			ByteOffset: field.Offset,
+		isPrimaryField[name] = true
+	}
+
+	for i := range fields {
+		if isPrimaryField[fields[i].Name] {
+			fields[i].PrimaryTag = true
 		}
 	}
 
-	return mapping.NewEntityMapping(
-		entityType,
-		"", "entity",
-		fieldMap,
-		map[string]*mapping.Child{},
-		fieldNames,
-		fieldNames,
-		[]string{},
-		fieldNames,
-		[]string{},
-	)
+	// Use BuildEntityMappings to create the mapping
+	metadata := map[reflect.Type]mapping.EntityMetadata{
+		entityType: {
+			Schema: "",
+			Table:  "entity",
+			Fields: fields,
+		},
+	}
+	registered := map[reflect.Type]bool{
+		entityType: true,
+	}
+
+	mappings := mapping.BuildEntityMappings(metadata, registered)
+	return mappings[entityType]
 }

--- a/mapping/mapping_test.go
+++ b/mapping/mapping_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hanpama/orm1"
 	"github.com/hanpama/orm1/mapping"
 )
 
@@ -31,6 +30,24 @@ type Comment struct {
 	ID     int64 `orm1:"primary"`
 	PostID int64 `orm1:"parental"`
 	Text   string
+}
+
+// buildTestMappings creates EntityMappings for testing without importing orm1.
+func buildTestMappings(entityTypes ...reflect.Type) map[reflect.Type]*mapping.EntityMapping {
+	metadata := make(map[reflect.Type]mapping.EntityMetadata)
+	registered := make(map[reflect.Type]bool)
+
+	for _, entityType := range entityTypes {
+		registered[entityType] = true
+		fields := mapping.AnalyzeStruct(entityType)
+		metadata[entityType] = mapping.EntityMetadata{
+			Schema: "",
+			Table:  mapping.ToSnakeCase(entityType.Name()),
+			Fields: fields,
+		}
+	}
+
+	return mapping.BuildEntityMappings(metadata, registered)
 }
 
 // TestField_GetValue tests Field.GetValue() with various types
@@ -62,9 +79,7 @@ func TestField_GetValue(t *testing.T) {
 		},
 	}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	for _, tt := range tests {
@@ -80,9 +95,7 @@ func TestField_GetValue(t *testing.T) {
 
 // TestField_SetValue tests Field.SetValue() with various types
 func TestField_SetValue(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	tests := []struct {
@@ -114,9 +127,7 @@ func TestField_SetValue(t *testing.T) {
 func TestField_GetPtr(t *testing.T) {
 	user := &User{ID: 123}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	field := em.FieldMap["ID"]
@@ -133,9 +144,7 @@ func TestField_GetPtr(t *testing.T) {
 
 // TestEntityMapping_Columns tests Columns() accessor
 func TestEntityMapping_Columns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	columns := em.Columns()
@@ -159,9 +168,7 @@ func TestEntityMapping_Columns(t *testing.T) {
 
 // TestEntityMapping_PrimaryColumns tests PrimaryColumns() accessor
 func TestEntityMapping_PrimaryColumns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	primaryColumns := em.PrimaryColumns()
@@ -180,9 +187,7 @@ func TestEntityMapping_PrimaryColumns_Composite(t *testing.T) {
 		Quantity  int
 	}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&OrderItem{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(OrderItem{}))
 	em := mappings[reflect.TypeOf(OrderItem{})]
 
 	primaryColumns := em.PrimaryColumns()
@@ -195,9 +200,7 @@ func TestEntityMapping_PrimaryColumns_Composite(t *testing.T) {
 
 // TestEntityMapping_InsertableColumns tests InsertableColumns() excludes skip_insert
 func TestEntityMapping_InsertableColumns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	insertable := em.InsertableColumns()
@@ -232,9 +235,7 @@ func TestEntityMapping_InsertableColumns(t *testing.T) {
 
 // TestEntityMapping_UpdatableColumns tests UpdatableColumns() excludes skip_update and primary
 func TestEntityMapping_UpdatableColumns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	updatable := em.UpdatableColumns()
@@ -268,11 +269,7 @@ func TestEntityMapping_UpdatableColumns(t *testing.T) {
 
 // TestEntityMapping_ParentalColumns tests ParentalColumns()
 func TestEntityMapping_ParentalColumns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	parentalColumns := postMapping.ParentalColumns()
@@ -285,9 +282,7 @@ func TestEntityMapping_ParentalColumns(t *testing.T) {
 
 // TestEntityMapping_InsertReturningColumns tests InsertReturningColumns()
 func TestEntityMapping_InsertReturningColumns(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	returning := em.InsertReturningColumns()
@@ -312,9 +307,7 @@ func TestEntityMapping_InsertReturningColumns(t *testing.T) {
 
 // TestEntityMapping_InsertReturning tests InsertReturning() field names
 func TestEntityMapping_InsertReturning(t *testing.T) {
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}))
 	em := mappings[reflect.TypeOf(User{})]
 
 	returning := em.InsertReturning()
@@ -342,11 +335,7 @@ func TestChild_Get_Singular(t *testing.T) {
 	author := &User{ID: 1, Name: "Alice"}
 	post := &Post{ID: 100, Author: author}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Author"]
@@ -368,11 +357,7 @@ func TestChild_Get_Plural(t *testing.T) {
 	comment2 := &Comment{ID: 2, Text: "Second"}
 	post := &Post{ID: 100, Comments: []*Comment{comment1, comment2}}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Comments"]
@@ -392,11 +377,7 @@ func TestChild_Get_Plural(t *testing.T) {
 func TestChild_Get_NilSingular(t *testing.T) {
 	post := &Post{ID: 100, Author: nil}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Author"]
@@ -413,11 +394,7 @@ func TestChild_Set_Singular(t *testing.T) {
 	post := &Post{ID: 100}
 	author := &User{ID: 1, Name: "Alice"}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Author"]
@@ -435,11 +412,7 @@ func TestChild_Set_Plural(t *testing.T) {
 	comment1 := &Comment{ID: 1, Text: "First"}
 	comment2 := &Comment{ID: 2, Text: "Second"}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Comments"]
@@ -476,11 +449,7 @@ func TestChild_Set_NilPlural(t *testing.T) {
 	post := &Post{ID: 100, Comments: nil}
 	comment1 := &Comment{ID: 1, Text: "First"}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Comments"]
@@ -503,11 +472,7 @@ func TestChild_Set_EmptySingular(t *testing.T) {
 	author := &User{ID: 1, Name: "Alice"}
 	post := &Post{ID: 100, Author: author}
 
-	builder := orm1.NewRegistry()
-	builder.Register(&User{})
-	builder.Register(&Post{})
-	builder.Register(&Comment{})
-	mappings := builder.Build()
+	mappings := buildTestMappings(reflect.TypeOf(User{}), reflect.TypeOf(Post{}), reflect.TypeOf(Comment{}))
 
 	postMapping := mappings[reflect.TypeOf(Post{})]
 	child := postMapping.ChildMap["Author"]

--- a/pagination_composite_test.go
+++ b/pagination_composite_test.go
@@ -47,8 +47,7 @@ func TestPaginationCompositeAscForwardNullsLast(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -111,8 +110,7 @@ func TestPaginationCompositeAscBackwardNullsLast(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -173,8 +171,7 @@ func TestPaginationCompositeAscForwardNullsFirst(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -219,8 +216,7 @@ func TestPaginationCompositeAscBackwardNullsFirst(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -265,8 +261,7 @@ func TestPaginationCompositeDescForwardNullsLast(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -311,8 +306,7 @@ func TestPaginationCompositeDescBackwardNullsLast(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -373,8 +367,7 @@ func TestPaginationCompositeDescForwardNullsFirst(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -435,8 +428,7 @@ func TestPaginationCompositeDescBackwardNullsFirst(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -500,8 +492,7 @@ func TestPaginationCompositeAscDefaultNulls(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -564,8 +555,7 @@ func TestPaginationCompositeDescDefaultNulls(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -627,8 +617,7 @@ func TestPaginationCompositeAscBackwardDefaultNulls(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 
@@ -689,8 +678,7 @@ func TestPaginationCompositeDescBackwardDefaultNulls(t *testing.T) {
 			ctx := context.Background()
 			registry := orm1.NewRegistry()
 			registry.Register(&BlogPostComposite{},
-				orm1.WithTable("blog_posts_composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("blog_posts_composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 			session := factory.CreateSession()
 

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -244,8 +244,7 @@ func TestPersistenceComposite(t *testing.T) {
 			// Create session factory and register entity
 			registry := orm1.NewRegistry()
 			registry.Register(&Composite{},
-				orm1.WithTable("composite"),
-				orm1.WithPrimaryKey("Key1", "Key2"))
+				orm1.WithTable("composite"))
 			factory := orm1.NewSessionFactory(registry, drv.driver)
 
 			session := factory.CreateSession()

--- a/registry.go
+++ b/registry.go
@@ -10,24 +10,16 @@ import (
 // It analyzes struct fields to determine columns, relationships, and keys.
 type Registry struct {
 	registered map[reflect.Type]bool
-	configs    map[reflect.Type]*entityConfig
+	metadata   map[reflect.Type]mapping.EntityMetadata
 	mappings   map[reflect.Type]*mapping.EntityMapping
 	built      bool
-}
-
-// entityConfig holds configuration for an entity mapping.
-type entityConfig struct {
-	Schema      string
-	Table       string
-	PrimaryKey  []string
-	ParentalKey []string
 }
 
 // NewRegistry creates a new registry.
 func NewRegistry() *Registry {
 	return &Registry{
 		registered: make(map[reflect.Type]bool),
-		configs:    make(map[reflect.Type]*entityConfig),
+		metadata:   make(map[reflect.Type]mapping.EntityMetadata),
 		mappings:   make(map[reflect.Type]*mapping.EntityMapping),
 	}
 }
@@ -123,25 +115,21 @@ func (r *Registry) Register(entityPtr any, opts ...MappingOption) {
 
 	r.registered[entityType] = true
 
-	config := &entityConfig{
-		Schema:      "",
-		Table:       mapping.ToSnakeCase(entityType.Name()),
-		PrimaryKey:  nil,
-		ParentalKey: nil,
-	}
-	r.configs[entityType] = config
+	// Analyze struct to get field metadata
+	fields := mapping.AnalyzeStruct(entityType)
 
-	tempMapping := &mapping.EntityMapping{
-		Schema:     config.Schema,
-		Table:      config.Table,
-		PrimaryKey: config.PrimaryKey,
+	meta := mapping.EntityMetadata{
+		Schema: "",
+		Table:  mapping.ToSnakeCase(entityType.Name()),
+		Fields: fields,
 	}
+
+	// Apply options to configure metadata
 	for _, opt := range opts {
-		opt(tempMapping)
+		opt(&meta)
 	}
-	config.Schema = tempMapping.Schema
-	config.Table = tempMapping.Table
-	config.PrimaryKey = tempMapping.PrimaryKey
+
+	r.metadata[entityType] = meta
 }
 
 // Build constructs EntityMapping instances for all registered types.
@@ -151,179 +139,18 @@ func (r *Registry) Build() map[reflect.Type]*mapping.EntityMapping {
 		return r.mappings
 	}
 
-	for entityType := range r.registered {
-		if _, ok := r.mappings[entityType]; !ok {
-			entityMapping := r.buildMapping(entityType)
-			r.mappings[entityType] = entityMapping
-		}
-	}
-
+	r.mappings = mapping.BuildEntityMappings(r.metadata, r.registered)
 	r.built = true
 
 	return r.mappings
 }
 
-// buildMapping constructs an EntityMapping for a single entity type.
-func (r *Registry) buildMapping(entityType reflect.Type) *mapping.EntityMapping {
-	config := r.configs[entityType]
-
-	fieldMap := make(map[string]*mapping.Field)
-	childMap := make(map[string]*mapping.Child)
-	allFields := []string{}
-	primaryKey := []string{}
-	parentalKey := []string{}
-	insertable := []string{}
-	updatable := []string{}
-
-	fieldsMetadata := mapping.AnalyzeStruct(entityType)
-
-	for _, metadata := range fieldsMetadata {
-		fieldName := metadata.Name
-		fieldType := metadata.Typ
-
-		if metadata.IgnoreTag {
-			continue
-		}
-
-		isChild := metadata.ChildTag
-		var childTarget reflect.Type
-		var childSingular bool
-
-		if !isChild {
-			// Auto-detect child relationship if not explicitly tagged
-			// Check for slice of registered type: []*Post
-			if fieldType.Kind() == reflect.Slice {
-				elemType := fieldType.Elem()
-				if elemType.Kind() == reflect.Ptr {
-					targetType := elemType.Elem()
-					if r.registered[targetType] {
-						isChild = true
-						childTarget = targetType
-						childSingular = false
-					}
-				}
-			}
-
-			if !isChild && fieldType.Kind() == reflect.Ptr {
-				targetType := fieldType.Elem()
-				if r.registered[targetType] {
-					isChild = true
-					childTarget = targetType
-					childSingular = true
-				}
-			}
-		} else {
-			if fieldType.Kind() == reflect.Slice {
-				elemType := fieldType.Elem()
-				if elemType.Kind() == reflect.Ptr {
-					childTarget = elemType.Elem()
-					childSingular = false
-				}
-			} else if fieldType.Kind() == reflect.Ptr {
-				childTarget = fieldType.Elem()
-				childSingular = true
-			}
-		}
-
-		if isChild {
-			child := mapping.Child{
-				Target:     childTarget,
-				Singular:   childSingular,
-				Type:       fieldType,
-				ByteOffset: metadata.ByteOffset,
-			}
-			childMap[fieldName] = &child
-			continue
-		}
-
-		if fieldType.Kind() == reflect.Slice {
-			continue
-		}
-
-		if fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct {
-			continue
-		}
-
-		columnName := metadata.ColumnTag
-		if columnName == "" {
-			columnName = metadata.DefaultColumn
-		}
-
-		field := mapping.Field{
-			Name:       metadata.Name,
-			Column:     columnName,
-			Type:       metadata.Typ,
-			ByteOffset: metadata.ByteOffset,
-		}
-
-		fieldMap[fieldName] = &field
-
-		isPrimaryKey := metadata.PrimaryTag
-		isParentalKey := metadata.ParentalTag
-
-		if !isPrimaryKey && !isParentalKey {
-			if len(config.PrimaryKey) > 0 {
-				// Use configured primary key
-				for _, pkField := range config.PrimaryKey {
-					if pkField == fieldName {
-						isPrimaryKey = true
-						break
-					}
-				}
-			} else {
-				// Default: ID field is primary key
-				isPrimaryKey = (fieldName == "ID")
-			}
-		}
-
-		// Add to AllFields (all fields are included regardless of role)
-		allFields = append(allFields, fieldName)
-
-		// A field can be both primary and parental (e.g., 1:1 relationship where PK=FK)
-		if isPrimaryKey {
-			primaryKey = append(primaryKey, fieldName)
-		}
-		if isParentalKey {
-			parentalKey = append(parentalKey, fieldName)
-		}
-
-		if isPrimaryKey || isParentalKey {
-			// Primary/parental keys are insertable unless tagged skip_insert
-			if !metadata.SkipInsertTag {
-				insertable = append(insertable, fieldName)
-			}
-			// Primary/parental keys are not updatable (they define identity)
-		} else {
-			// Regular fields are insertable and updatable unless tagged otherwise
-			if !metadata.SkipInsertTag {
-				insertable = append(insertable, fieldName)
-			}
-			if !metadata.SkipUpdateTag {
-				updatable = append(updatable, fieldName)
-			}
-		}
-	}
-
-	return mapping.NewEntityMapping(
-		entityType,
-		config.Schema,
-		config.Table,
-		fieldMap,
-		childMap,
-		allFields,
-		primaryKey,
-		parentalKey,
-		insertable,
-		updatable,
-	)
-}
-
-// MappingOption is a function that configures an EntityMapping.
-type MappingOption func(*mapping.EntityMapping)
+// MappingOption is a function that configures an EntityMetadata.
+type MappingOption func(*mapping.EntityMetadata)
 
 // WithSchema sets the database schema for the entity's table.
 func WithSchema(schema string) MappingOption {
-	return func(m *mapping.EntityMapping) {
+	return func(m *mapping.EntityMetadata) {
 		m.Schema = schema
 	}
 }
@@ -331,15 +158,8 @@ func WithSchema(schema string) MappingOption {
 // WithTable sets the table name for the entity.
 // If not specified, defaults to snake_case of the struct name.
 func WithTable(table string) MappingOption {
-	return func(m *mapping.EntityMapping) {
+	return func(m *mapping.EntityMetadata) {
 		m.Table = table
 	}
 }
 
-// WithPrimaryKey specifies the field names that form the primary key.
-// If not specified, defaults to the "ID" field.
-func WithPrimaryKey(fieldNames ...string) MappingOption {
-	return func(m *mapping.EntityMapping) {
-		m.PrimaryKey = fieldNames
-	}
-}

--- a/registry_test.go
+++ b/registry_test.go
@@ -343,26 +343,6 @@ func TestWithTable(t *testing.T) {
 	}
 }
 
-// TestWithPrimaryKey tests WithPrimaryKey option
-func TestWithPrimaryKey(t *testing.T) {
-	type User struct {
-		UserID   int64
-		TenantID int64
-		Name     string
-	}
-
-	builder := orm1.NewRegistry()
-	builder.Register(&User{}, orm1.WithPrimaryKey("UserID", "TenantID"))
-	mappings := builder.Build()
-
-	em := mappings[reflect.TypeOf(User{})]
-
-	expected := []string{"UserID", "TenantID"}
-	if !reflect.DeepEqual(em.PrimaryKey, expected) {
-		t.Errorf("PrimaryKey = %v, want %v", em.PrimaryKey, expected)
-	}
-}
-
 // TestBuilder_MultipleEntities tests registering multiple entities
 func TestBuilder_MultipleEntities(t *testing.T) {
 	type User struct {
@@ -403,7 +383,7 @@ func TestBuilder_MultipleEntities(t *testing.T) {
 // TestBuilder_MultipleOptions tests combining multiple options
 func TestBuilder_MultipleOptions(t *testing.T) {
 	type User struct {
-		UserID int64
+		UserID int64 `orm1:"primary"`
 		Name   string
 	}
 
@@ -412,7 +392,6 @@ func TestBuilder_MultipleOptions(t *testing.T) {
 		&User{},
 		orm1.WithSchema("public"),
 		orm1.WithTable("users"),
-		orm1.WithPrimaryKey("UserID"),
 	)
 	mappings := builder.Build()
 

--- a/testentity_test.go
+++ b/testentity_test.go
@@ -22,8 +22,8 @@ type SimpleUUID struct {
 
 // Composite - composite PK with all field attributes
 type Composite struct {
-	Key1          int
-	Key2          int
+	Key1          int    `orm1:"primary"`
+	Key2          int    `orm1:"primary"`
 	Name          string
 	SkipInsert    string `orm1:"skip_insert"`
 	SkipUpdate    string `orm1:"skip_update"`
@@ -106,8 +106,8 @@ type BlogPost struct {
 }
 
 type BlogPostComposite struct {
-	Key1        int64
-	Key2        int64
+	Key1        int64 `orm1:"primary"`
+	Key2        int64 `orm1:"primary"`
 	Title       string
 	Rating      *int
 	PublishedAt *int64


### PR DESCRIPTION
This commit eliminates circular dependencies by introducing a clean separation between pure data structures and builder logic in the mapping package.

## Changes

### New: mapping/build.go
- Added `EntityMetadata` struct: pure data structure containing all entity configuration (Schema, Table, Fields)
- Added `BuildEntityMappings()`: pure builder function that transforms EntityMetadata into EntityMapping without reflection
- Extracted all entity mapping construction logic from Registry

### registry.go refactoring
- Removed `entityConfig` internal struct
- Removed `buildMapping()` method (logic moved to mapping.BuildEntityMappings)
- `Register()` now calls `AnalyzeStruct()` to populate EntityMetadata.Fields
- `Build()` delegates to `mapping.BuildEntityMappings()`
- Changed `MappingOption` signature: `func(*EntityMapping)` → `func(*EntityMetadata)`
- **Removed `WithPrimaryKey()` option** - use `orm1:"primary"` tags instead

### mapping package independence
- `mapping_test.go` no longer imports `github.com/hanpama/orm1`
- Added `buildTestMappings()` helper that directly uses `BuildEntityMappings()`
- `extract_test.go` updated to use `BuildEntityMappings()`

### Test updates
- Removed `TestWithPrimaryKey` test
- Added `orm1:"primary"` tags to `Composite` and `BlogPostComposite` entities
- Updated all tests to remove `WithPrimaryKey()` calls